### PR TITLE
Update 2016-05-03-introducing-nuget.md

### DIFF
--- a/_posts/2016-05-03-introducing-nuget.md
+++ b/_posts/2016-05-03-introducing-nuget.md
@@ -36,7 +36,7 @@ to accomplish:
 
 ![NuGet Package Dependencies](/assets/nuget_dependencies.png)
 
-With NuGet infrastructure in place, creation of new imaging project is a breathe.
+With NuGet infrastructure in place, creation of new imaging project is a breeze.
 All you need is to download the packages you want and drop some code into the pot!
 
 We provide two flavors of each package - x86 and x64 (there are rare exceptions though -


### PR DESCRIPTION
Please note: this issue is merely a case where it might not be apparent to someone who did not grow up as a native English speaker:
""" With NuGet infrastructure in place, creation of new imaging project is a breathe."""

The correct word is "breeze", not "breathe"

so it should read
""" With NuGet infrastructure in place, creation of new imaging project is a breeze."""